### PR TITLE
[HttpKernel] Remove private headers before storing responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php56": "~1.0",
-        "symfony/polyfill-php70": "~1.6"
+        "symfony/polyfill-php70": "~1.6",
+        "laminas/laminas-zendframework-bridge": "1.6.x-dev"
     },
     "replace": {
         "symfony/asset": "self.version",

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -26,21 +26,30 @@ class Store implements StoreInterface
 {
     protected $root;
     private $keyCache;
-    private $locks;
+    private $locks = [];
+    private $options;
 
     /**
      * @param string $root The path to the cache directory
+     * @param array $options List of options
+     *
+     * The available options are:
+     *
+     *   * private_headers  Set of response headers that should not be stored
+     *                      when a response is cached. (default: Set-Cookie)
      *
      * @throws \RuntimeException
      */
-    public function __construct($root)
+    public function __construct($root, array $options = [])
     {
         $this->root = $root;
         if (!file_exists($this->root) && !@mkdir($this->root, 0777, true) && !is_dir($this->root)) {
             throw new \RuntimeException(sprintf('Unable to create the store directory (%s).', $this->root));
         }
         $this->keyCache = new \SplObjectStorage();
-        $this->locks = [];
+        $this->options = array_merge([
+            'private_headers' => ['Set-Cookie'],
+        ], $options);
     }
 
     /**
@@ -216,6 +225,10 @@ class Store implements StoreInterface
 
         $headers = $this->persistResponse($response);
         unset($headers['age']);
+
+        foreach ($this->options['private_headers'] as $h) {
+            unset($headers[strtolower($h)]);
+        }
 
         array_unshift($entries, [$storedEnv, $headers]);
 


### PR DESCRIPTION
security #[CVE-2022-24894](https://github.com/advisories/GHSA-h7vf-5wrv-9fhv) Symfony storing cookie headers in HttpCache 

Based on 4.4 branch fix : https://github.com/symfony/symfony/commit/d2f6322af9444ac5cd1ef3ac6f280dbef7f9d1fb

laminas/laminas-zendframework-bridge is required for SF 3.4 tests : https://github.com/symfony/symfony/issues/41742