### PR TITLE
[Security/Http] Remove CSRF tokens from storage on successful login

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -61,6 +61,7 @@
 
         <service id="security.authentication.session_strategy" class="Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy">
             <argument>%security.authentication.session_strategy.strategy%</argument>
+            <argument type="service" id="security.csrf.token_storage" on-invalid="ignore" />
         </service>
         <service id="Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface" alias="security.authentication.session_strategy" />
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/CsrfFormLoginTest.php
@@ -19,11 +19,14 @@ class CsrfFormLoginTest extends AbstractWebTestCase
     public function testFormLoginAndLogoutWithCsrfTokens($config)
     {
         $client = $this->createClient(['test_case' => 'CsrfFormLogin', 'root_config' => $config]);
+        static::$kernel->getContainer()->get('test.security.csrf.token_storage')->setToken('foo', 'bar');
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();
         $form['user_login[username]'] = 'johannes';
         $form['user_login[password]'] = 'test';
         $client->submit($form);
+
+        $this->assertFalse(static::$kernel->getContainer()->get('test.security.csrf.token_storage')->hasToken('foo'));
 
         $this->assertRedirect($client->getResponse(), '/profile');
 
@@ -49,10 +52,13 @@ class CsrfFormLoginTest extends AbstractWebTestCase
     public function testFormLoginWithInvalidCsrfToken($config)
     {
         $client = $this->createClient(['test_case' => 'CsrfFormLogin', 'root_config' => $config]);
+        static::$kernel->getContainer()->get('test.security.csrf.token_storage')->setToken('foo', 'bar');
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();
         $form['user_login[_token]'] = '';
         $client->submit($form);
+
+        $this->assertTrue(static::$kernel->getContainer()->get('test.security.csrf.token_storage')->hasToken('foo'));
 
         $this->assertRedirect($client->getResponse(), '/login');
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
@@ -35,15 +35,13 @@ class LogoutTest extends AbstractWebTestCase
     public function testCsrfTokensAreClearedOnLogout()
     {
         $client = $this->createClient(['test_case' => 'LogoutWithoutSessionInvalidation', 'root_config' => 'config.yml']);
-        static::$kernel->getContainer()->get('test.security.csrf.token_storage')->setToken('foo', 'bar');
 
         $client->request('POST', '/login', [
             '_username' => 'johannes',
             '_password' => 'test',
         ]);
 
-        $this->assertTrue(static::$kernel->getContainer()->get('test.security.csrf.token_storage')->hasToken('foo'));
-        $this->assertSame('bar', static::$kernel->getContainer()->get('test.security.csrf.token_storage')->getToken('foo'));
+        static::$kernel->getContainer()->get('test.security.csrf.token_storage')->setToken('foo', 'bar');
 
         $client->request('GET', '/logout');
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
@@ -8,6 +8,9 @@ services:
             - '@request_stack'
         tags:
             - { name: form.type }
+    test.security.csrf.token_storage:
+        alias: security.csrf.token_storage
+        public: true
 
 security:
     encoders:

--- a/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
+++ b/src/Symfony/Component/Security/Http/Session/SessionAuthenticationStrategy.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Session;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
 
 /**
  * The default session strategy implementation.
@@ -31,10 +32,15 @@ class SessionAuthenticationStrategy implements SessionAuthenticationStrategyInte
     const INVALIDATE = 'invalidate';
 
     private $strategy;
+    private $csrfTokenStorage = null;
 
-    public function __construct($strategy)
+    public function __construct($strategy, ClearableTokenStorageInterface $csrfTokenStorage = null)
     {
         $this->strategy = $strategy;
+
+        if (self::MIGRATE === $strategy) {
+            $this->csrfTokenStorage = $csrfTokenStorage;
+        }
     }
 
     /**
@@ -47,9 +53,11 @@ class SessionAuthenticationStrategy implements SessionAuthenticationStrategyInte
                 return;
 
             case self::MIGRATE:
-                // Note: this logic is duplicated in several authentication listeners
-                // until Symfony 5.0 due to a security fix with BC compat
                 $request->getSession()->migrate(true);
+
+                if ($this->csrfTokenStorage) {
+                    $this->csrfTokenStorage->clear();
+                }
 
                 return;
 

--- a/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Session/SessionAuthenticationStrategyTest.php
@@ -54,6 +54,18 @@ class SessionAuthenticationStrategyTest extends TestCase
         $strategy->onAuthentication($this->getRequest($session), $this->getToken());
     }
 
+    public function testCsrfTokensAreCleared()
+    {
+        $session = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\SessionInterface')->getMock();
+        $session->expects($this->once())->method('migrate')->with($this->equalTo(true));
+
+        $csrfStorage = $this->getMockBuilder('Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface')->getMock();
+        $csrfStorage->expects($this->once())->method('clear');
+
+        $strategy = new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE, $csrfStorage);
+        $strategy->onAuthentication($this->getRequest($session), $this->getToken());
+    }
+
     private function getRequest($session = null)
     {
         $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();


### PR DESCRIPTION
security #[CVE-2022-24895](https://github.com/advisories/GHSA-3gv2-29qc-v67m) Symfony vulnerable to Session Fixation of CSRF tokens

Based on 4.4 branch fix : https://github.com/symfony/symfony/commit/5909d74ecee359ea4982fcf4331aaf2e489a1fd4